### PR TITLE
temporary workaround to avoid SQL error

### DIFF
--- a/plugins/source/aws/policies/queries/lambda/lambda_function_prohibit_public_access.sql
+++ b/plugins/source/aws/policies/queries/lambda/lambda_function_prohibit_public_access.sql
@@ -19,5 +19,7 @@ where statement ->> 'Effect' = 'Allow'
     and (
         statement ->> 'Principal' = '*'
         or statement -> 'Principal' ->> 'AWS' = '*'
-        or (statement -> 'Principal' ->> 'AWS')::JSONB ? '*'
+-- Temporarily disable to avoid bug
+-- https://github.com/cloudquery/cloudquery/issues/9763
+--        or (statement -> 'Principal' ->> 'AWS')::JSONB ? '*'
     )


### PR DESCRIPTION
Temporarily disable SQL clause to avoid errors. See https://github.com/cloudquery/cloudquery/issues/9763