### PR TITLE
fix: invert policy query results for  EC2 EBS snapshots sharing

### DIFF
--- a/plugins/source/aws/policies/queries/ec2/ebs_snapshot_permissions_check.sql
+++ b/plugins/source/aws/policies/queries/ec2/ebs_snapshot_permissions_check.sql
@@ -19,7 +19,7 @@ SELECT DISTINCT
     -- this is under question because
     -- trusted accounts(user_id) do not violate this control
         OR user_id IS DISTINCT FROM ''
-    then 'pass'
-    else 'fail'
+    then 'fail'
+    else 'pass'
   end as status
 FROM snapshot_access_groups


### PR DESCRIPTION
Shared EC2 EBS snapshots should fail. Snapshots not shared should pass.

Fixes  #https://github.com/cloudquery/cloudquery/issues/10140
